### PR TITLE
Remove Unnecessary Properties

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -21,14 +21,14 @@ var m sync.Mutex
 
 // RefreshRiskAssessments pulls the risk assessment data from REDCap and posts it to the FHIR server, replacing older
 // risk assessments and storing pie representations.
-func RefreshRiskAssessments(fhirEndpoint string, redcapEndpoint string, redcapToken string, pieCollection *mgo.Collection, basisPieURL string, useStudyID bool) ([]Result, error) {
+func RefreshRiskAssessments(fhirEndpoint string, redcapEndpoint string, redcapToken string, pieCollection *mgo.Collection, basisPieURL string) ([]Result, error) {
 	m.Lock()
 	defer m.Unlock()
 	studies, err := GetREDCapData(redcapEndpoint, redcapToken)
 	if err != nil {
 		return nil, err
 	}
-	return PostRiskAssessments(fhirEndpoint, studies, pieCollection, basisPieURL, useStudyID), nil
+	return PostRiskAssessments(fhirEndpoint, studies, pieCollection, basisPieURL), nil
 }
 
 // GetREDCapData queries REDCap at the specified endpoint with the specifed token, returning a StudyMap containing
@@ -40,7 +40,7 @@ func GetREDCapData(endpoint string, token string) (models.StudyMap, error) {
 	form.Set("format", "json")
 	form.Set("returnFormat", "json")
 	form.Set("type", "flat")
-	form.Set("fields", "study_id, redcap_event_name, mrn, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted")
+	form.Set("fields", "study_id, redcap_event_name, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted")
 
 	if !strings.HasSuffix(endpoint, "/") {
 		endpoint += "/"
@@ -67,19 +67,14 @@ func GetREDCapData(endpoint string, token string) (models.StudyMap, error) {
 
 // PostRiskAssessments posts the risk assessments from the studies to the FHIR server and also stores the risk pies
 // to the local Mongo database
-func PostRiskAssessments(fhirEndpoint string, studies models.StudyMap, pieCollection *mgo.Collection, basisPieURL string, useStudyID bool) []Result {
+func PostRiskAssessments(fhirEndpoint string, studies models.StudyMap, pieCollection *mgo.Collection, basisPieURL string) []Result {
 	results := make([]Result, 0, len(studies))
 	for _, study := range studies {
-		mrn := study.MedicalRecordNumber
-		if useStudyID {
-			mrn = study.ID
-		}
 		result := Result{
-			StudyID:             study.ID,
-			MedicalRecordNumber: mrn,
+			StudyID: study.ID,
 		}
-		// Query the FHIR server to find the patient ID by MRN
-		r, err := http.NewRequest("GET", fhirEndpoint+"/Patient?identifier="+mrn, nil)
+		// Query the FHIR server to find the patient ID by the Study ID (often the MRN)
+		r, err := http.NewRequest("GET", fhirEndpoint+"/Patient?identifier="+study.ID, nil)
 		if err != nil {
 			result.Error = fmt.Errorf("Couldn't create HTTP request for querying patient with Study ID: %s.  Error: %s", study.ID, err.Error())
 			results = append(results, result)
@@ -106,11 +101,11 @@ func PostRiskAssessments(fhirEndpoint string, studies models.StudyMap, pieCollec
 			continue
 		}
 		if len(patients.Entry) == 0 {
-			result.Error = fmt.Errorf("Couldn't find patient with MRN %s for Study ID %s", mrn, study.ID)
+			result.Error = fmt.Errorf("Couldn't find patient with Study ID %s", study.ID)
 			results = append(results, result)
 			continue
 		} else if len(patients.Entry) > 1 {
-			result.Error = fmt.Errorf("Found too many patients (%d) with MRN %s for Study ID %s", len(patients.Entry), mrn, study.ID)
+			result.Error = fmt.Errorf("Found too many patients (%d) with Study ID %s", len(patients.Entry), study.ID)
 			results = append(results, result)
 			continue
 		}
@@ -134,7 +129,6 @@ func PostRiskAssessments(fhirEndpoint string, studies models.StudyMap, pieCollec
 // Result represents the result (successful or not) of posting REDCap risk assessments to a FHIR server
 type Result struct {
 	StudyID             string
-	MedicalRecordNumber string
 	FHIRPatientID       string
 	RiskAssessmentCount int
 	Error               error
@@ -148,13 +142,11 @@ func (r *Result) MarshalJSON() ([]byte, error) {
 	}
 	return json.Marshal(&struct {
 		StudyID             string `json:"studyID,omitempty"`
-		MedicalRecordNumber string `json:"medicalRecordNumber,omitempty"`
 		FHIRPatientID       string `json:"fhirPatientID,omitempty"`
 		RiskAssessmentCount int    `json:"riskAssessmentCount"`
 		Error               string `json:"error,omitempty"`
 	}{
 		StudyID:             r.StudyID,
-		MedicalRecordNumber: r.MedicalRecordNumber,
 		FHIRPatientID:       r.FHIRPatientID,
 		RiskAssessmentCount: r.RiskAssessmentCount,
 		Error:               errString,

--- a/client/client.go
+++ b/client/client.go
@@ -40,7 +40,7 @@ func GetREDCapData(endpoint string, token string) (models.StudyMap, error) {
 	form.Set("format", "json")
 	form.Set("returnFormat", "json")
 	form.Set("type", "flat")
-	form.Set("fields", "study_id, redcap_event_name, mrn, participant_information_complete, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted, risk_factors_complete")
+	form.Set("fields", "study_id, redcap_event_name, mrn, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted")
 
 	if !strings.HasSuffix(endpoint, "/") {
 		endpoint += "/"

--- a/client/fhir_client_test.go
+++ b/client/fhir_client_test.go
@@ -102,20 +102,18 @@ func (suite *FHIRClientSuite) TestPostRiskAssessments() {
 
 	// Post the studies as risk assessments
 	piesCollection := suite.Database.C("pies")
-	results := PostRiskAssessments(suite.Server.URL, suite.Studies, piesCollection, suite.Server.URL+"/pies", false)
+	results := PostRiskAssessments(suite.Server.URL, suite.Studies, piesCollection, suite.Server.URL+"/pies")
 	assert.Len(results, 2)
 
 	// Check the results
 	assert.Contains(results, Result{
 		StudyID:             "1",
-		MedicalRecordNumber: "1-1",
 		FHIRPatientID:       "56fd63cdac1c5d77f6f695a1",
 		RiskAssessmentCount: 2,
 		Error:               nil,
 	})
 	assert.Contains(results, Result{
 		StudyID:             "a",
-		MedicalRecordNumber: "1-a",
 		FHIRPatientID:       "56fd63cdac1c5d77f6f695a2",
 		RiskAssessmentCount: 1,
 		Error:               nil,
@@ -146,33 +144,31 @@ func (suite *FHIRClientSuite) TestPostRiskAssessments() {
 	suite.checkPie(&ras[2], "56fd63cdac1c5d77f6f695a1", 3, 2, 1, 4)
 }
 
-func (suite *FHIRClientSuite) TestPostRiskAssessmentsWithUnfoundMRN() {
+func (suite *FHIRClientSuite) TestPostRiskAssessmentsWithUnfoundStudyID() {
 	require := suite.Require()
 	assert := suite.Assert()
 
-	// Change one of the MRNs so it isn't found on the FHIR server
-	suite.Studies["a"].MedicalRecordNumber = "FOO"
-	suite.Studies["a"].Records[0].MedicalRecordNumber = "FOO"
+	// Change one of the StudyIDs so it isn't found on the FHIR server
+	suite.Studies["a"].ID = "FOO"
+	suite.Studies["a"].Records[0].StudyID = "FOO"
 
 	// Post the studies as risk assessments
 	piesCollection := suite.Database.C("pies")
-	results := PostRiskAssessments(suite.Server.URL, suite.Studies, piesCollection, suite.Server.URL+"/pies", false)
+	results := PostRiskAssessments(suite.Server.URL, suite.Studies, piesCollection, suite.Server.URL+"/pies")
 	assert.Len(results, 2)
 
 	// Check the results
 	assert.Contains(results, Result{
 		StudyID:             "1",
-		MedicalRecordNumber: "1-1",
 		FHIRPatientID:       "56fd63cdac1c5d77f6f695a1",
 		RiskAssessmentCount: 2,
 		Error:               nil,
 	})
 	assert.Contains(results, Result{
-		StudyID:             "a",
-		MedicalRecordNumber: "FOO",
+		StudyID:             "FOO",
 		FHIRPatientID:       "",
 		RiskAssessmentCount: 0,
-		Error:               errors.New("Couldn't find patient with MRN FOO for Study ID a"),
+		Error:               errors.New("Couldn't find patient with Study ID FOO"),
 	})
 
 	// Check we have the right number of risk assessments

--- a/client/redcap_client_test.go
+++ b/client/redcap_client_test.go
@@ -33,7 +33,7 @@ func (suite *REDCapClientSuite) SetupTest() {
 		assert.Equal("record", r.FormValue("content"))
 		assert.Equal("json", r.FormValue("format"))
 		assert.Equal("flat", r.FormValue("type"))
-		assert.Equal("study_id, redcap_event_name, mrn, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted", r.FormValue("fields"))
+		assert.Equal("study_id, redcap_event_name, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted", r.FormValue("fields"))
 		assert.Equal("json", r.FormValue("returnFormat"))
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
@@ -58,12 +58,10 @@ func (suite *REDCapClientSuite) TestGetREDCapData() {
 	s, ok := m["1"]
 	require.True(ok)
 	assert.Equal("1", s.ID)
-	assert.Equal("1-1", s.MedicalRecordNumber)
 	require.Len(s.Records, 2)
 
 	s, ok = m["a"]
 	require.True(ok)
 	assert.Equal("a", s.ID)
-	assert.Equal("1-a", s.MedicalRecordNumber)
 	require.Len(s.Records, 1)
 }

--- a/client/redcap_client_test.go
+++ b/client/redcap_client_test.go
@@ -33,7 +33,7 @@ func (suite *REDCapClientSuite) SetupTest() {
 		assert.Equal("record", r.FormValue("content"))
 		assert.Equal("json", r.FormValue("format"))
 		assert.Equal("flat", r.FormValue("type"))
-		assert.Equal("study_id, redcap_event_name, mrn, participant_information_complete, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted, risk_factors_complete", r.FormValue("fields"))
+		assert.Equal("study_id, redcap_event_name, mrn, rf_date, rf_cmc_risk_cat, rf_func_risk_cat, rf_sb_risk_cat, rf_util_risk_cat, rf_risk_predicted", r.FormValue("fields"))
 		assert.Equal("json", r.FormValue("returnFormat"))
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")

--- a/fixtures/example_records.json
+++ b/fixtures/example_records.json
@@ -3,39 +3,33 @@
     "study_id": 1,
     "redcap_event_name": "initial_arm_1",
     "mrn": "1-1",
-    "participant_information_complete": "2",
     "rf_date": "2015-12-07",
     "rf_cmc_risk_cat": "3",
     "rf_func_risk_cat": "2",
     "rf_sb_risk_cat": "1",
     "rf_util_risk_cat": "3",
-    "rf_risk_predicted": "3",
-    "risk_factors_complete": "2"
+    "rf_risk_predicted": "3"
   },
   {
     "study_id": 1,
     "redcap_event_name": "visit1_arm_1",
     "mrn": "",
-    "participant_information_complete": "",
     "rf_date": "2016-04-01",
     "rf_cmc_risk_cat": "3",
     "rf_func_risk_cat": "2",
     "rf_sb_risk_cat": "1",
     "rf_util_risk_cat": "4",
-    "rf_risk_predicted": "4",
-    "risk_factors_complete": "2"
+    "rf_risk_predicted": "4"
   },
   {
     "study_id": "a",
     "redcap_event_name": "initial_arm_1",
     "mrn": "1-a",
-    "participant_information_complete": "2",
     "rf_date": "2016-02-21",
     "rf_cmc_risk_cat": "1",
     "rf_func_risk_cat": "1",
     "rf_sb_risk_cat": "2",
     "rf_util_risk_cat": "1",
-    "rf_risk_predicted": "2",
-    "risk_factors_complete": "2"
+    "rf_risk_predicted": "2"
   }
 ]

--- a/fixtures/example_records.json
+++ b/fixtures/example_records.json
@@ -2,7 +2,6 @@
   {
     "study_id": 1,
     "redcap_event_name": "initial_arm_1",
-    "mrn": "1-1",
     "rf_date": "2015-12-07",
     "rf_cmc_risk_cat": "3",
     "rf_func_risk_cat": "2",
@@ -13,7 +12,6 @@
   {
     "study_id": 1,
     "redcap_event_name": "visit1_arm_1",
-    "mrn": "",
     "rf_date": "2016-04-01",
     "rf_cmc_risk_cat": "3",
     "rf_func_risk_cat": "2",
@@ -24,7 +22,6 @@
   {
     "study_id": "a",
     "redcap_event_name": "initial_arm_1",
-    "mrn": "1-a",
     "rf_date": "2016-02-21",
     "rf_cmc_risk_cat": "1",
     "rf_func_risk_cat": "1",

--- a/fixtures/patients_bundle.json
+++ b/fixtures/patients_bundle.json
@@ -10,7 +10,7 @@
                 "identifier": [
                     {
                         "type": { "coding": [ { "system": "http://hl7.org/fhir/v2/0203", "code": "MR" } ] },
-                        "value": "1-1"
+                        "value": "1"
                     }
                 ],
                 "name": [
@@ -33,7 +33,7 @@
                 "identifier": [
                     {
                         "type": { "coding": [ { "system": "http://hl7.org/fhir/v2/0203", "code": "MR" } ] },
-                        "value": "1-a"
+                        "value": "a"
                     }
                 ],
                 "name": [

--- a/main.go
+++ b/main.go
@@ -61,7 +61,7 @@ func main() {
 
 	// Setup the cron job and start the scheduler
 	c := cron.New()
-	err = server.ScheduleRefreshRiskAssessmentsCron(c, cronSpec, fhir, redcap, token, pieCollection, basisPieURL, true)
+	err = server.ScheduleRefreshRiskAssessmentsCron(c, cronSpec, fhir, redcap, token, pieCollection, basisPieURL)
 	if err != nil {
 		panic("Can't setup cron job for refreshing risk assessments.  Specified spec: " + cronSpec)
 	}
@@ -70,7 +70,7 @@ func main() {
 
 	// Create the gin engine, register the routes, and run!
 	e := gin.Default()
-	server.RegisterRoutes(e, fhir, redcap, token, pieCollection, basisPieURL, true)
+	server.RegisterRoutes(e, fhir, redcap, token, pieCollection, basisPieURL)
 	e.Run(httpa)
 }
 

--- a/mock/main.go
+++ b/mock/main.go
@@ -107,7 +107,6 @@ func RefreshMockRiskAssessments(fhirEndpoint string, pieCollection *mgo.Collecti
 		study := sum.ToStudy()
 		result := client.Result{
 			StudyID:             study.ID,
-			MedicalRecordNumber: study.MedicalRecordNumber,
 			FHIRPatientID:       id,
 		}
 		calcResults := study.ToRiskServiceCalculationResults(fhirEndpoint + "/Patient/" + id)
@@ -195,11 +194,9 @@ type patientSummary struct {
 func (p *patientSummary) ToStudy() models.Study {
 	var study models.Study
 	study.ID = p.ID
-	study.MedicalRecordNumber = p.ID
 	for d := time.Date(2014, time.June, 1, 12, 0, 0, 0, time.Local); d.Before(time.Now()); {
 		var record models.Record
 		record.StudyID = p.ID
-		record.MedicalRecordNumber = p.ID
 		record.RiskFactorDate = d.Format("2006-01-02")
 		if len(study.Records) == 0 {
 			p.populateInitialRecord(&record)

--- a/mock/main.go
+++ b/mock/main.go
@@ -200,9 +200,7 @@ func (p *patientSummary) ToStudy() models.Study {
 		var record models.Record
 		record.StudyID = p.ID
 		record.MedicalRecordNumber = p.ID
-		record.ParticipantInfoComplete = "2"
 		record.RiskFactorDate = d.Format("2006-01-02")
-		record.RiskFactorsComplete = "2"
 		if len(study.Records) == 0 {
 			p.populateInitialRecord(&record)
 		} else {

--- a/models/record.go
+++ b/models/record.go
@@ -13,9 +13,8 @@ import (
 
 // Record represents the key info from a REDCap record in the risk stratification project
 type Record struct {
-	StudyID             interface{} `json:"study_id"`
-	EventName           string      `json:"redcap_event_name"`
-	MedicalRecordNumber string      `json:"mrn"`
+	StudyID   interface{} `json:"study_id"`
+	EventName string      `json:"redcap_event_name"`
 
 	RiskFactorDate   string `json:"rf_date"`
 	ClinicalRisk     string `json:"rf_cmc_risk_cat"`

--- a/models/record.go
+++ b/models/record.go
@@ -13,18 +13,16 @@ import (
 
 // Record represents the key info from a REDCap record in the risk stratification project
 type Record struct {
-	StudyID                 interface{} `json:"study_id"`
-	EventName               string      `json:"redcap_event_name"`
-	MedicalRecordNumber     string      `json:"mrn"`
-	ParticipantInfoComplete string      `json:"participant_information_complete"`
+	StudyID             interface{} `json:"study_id"`
+	EventName           string      `json:"redcap_event_name"`
+	MedicalRecordNumber string      `json:"mrn"`
 
-	RiskFactorDate      string `json:"rf_date"`
-	ClinicalRisk        string `json:"rf_cmc_risk_cat"`
-	FunctionalRisk      string `json:"rf_func_risk_cat"`
-	PsychosocialRisk    string `json:"rf_sb_risk_cat"`
-	UtilizationRisk     string `json:"rf_util_risk_cat"`
-	PerceivedRisk       string `json:"rf_risk_predicted"`
-	RiskFactorsComplete string `json:"risk_factors_complete"`
+	RiskFactorDate   string `json:"rf_date"`
+	ClinicalRisk     string `json:"rf_cmc_risk_cat"`
+	FunctionalRisk   string `json:"rf_func_risk_cat"`
+	PsychosocialRisk string `json:"rf_sb_risk_cat"`
+	UtilizationRisk  string `json:"rf_util_risk_cat"`
+	PerceivedRisk    string `json:"rf_risk_predicted"`
 }
 
 // StudyIDString returns a string representation of the study ID (which could be a string or a number)
@@ -37,16 +35,10 @@ func (r *Record) RiskFactorDateTime() (time.Time, error) {
 	return time.ParseInLocation("2006-01-02", r.RiskFactorDate, time.Local)
 }
 
-// IsParticipationInfoComplete checks that the participation info form was marked as complete AND that a medical
-// record number exists
-func (r *Record) IsParticipationInfoComplete() bool {
-	return r.ParticipantInfoComplete == "2" && r.MedicalRecordNumber != ""
-}
-
 // IsRiskFactorsComplete checks that the risk factors form was marked as complete, that a valid risk factor date was
 // set, and that all risk factor scores are set
 func (r *Record) IsRiskFactorsComplete() bool {
-	return r.RiskFactorsComplete == "2" && r.RiskFactorDate != "" && r.ClinicalRisk != "" && r.FunctionalRisk != "" &&
+	return r.RiskFactorDate != "" && r.ClinicalRisk != "" && r.FunctionalRisk != "" &&
 		r.PsychosocialRisk != "" && r.UtilizationRisk != "" && r.PerceivedRisk != ""
 }
 

--- a/models/record_test.go
+++ b/models/record_test.go
@@ -34,43 +34,37 @@ func (suite *RecordSuite) TestLoadRecordsFromJSON() {
 	assert := suite.Assert()
 	assert.Len(suite.Records, 3)
 	assert.Equal(Record{
-		StudyID:                 float64(1),
-		EventName:               "initial_arm_1",
-		MedicalRecordNumber:     "1-1",
-		ParticipantInfoComplete: "2",
-		RiskFactorDate:          "2015-12-07",
-		ClinicalRisk:            "3",
-		FunctionalRisk:          "2",
-		PsychosocialRisk:        "1",
-		UtilizationRisk:         "3",
-		PerceivedRisk:           "3",
-		RiskFactorsComplete:     "2",
+		StudyID:             float64(1),
+		EventName:           "initial_arm_1",
+		MedicalRecordNumber: "1-1",
+		RiskFactorDate:      "2015-12-07",
+		ClinicalRisk:        "3",
+		FunctionalRisk:      "2",
+		PsychosocialRisk:    "1",
+		UtilizationRisk:     "3",
+		PerceivedRisk:       "3",
 	}, suite.Records[0])
 	assert.Equal(Record{
-		StudyID:                 float64(1),
-		EventName:               "visit1_arm_1",
-		MedicalRecordNumber:     "",
-		ParticipantInfoComplete: "",
-		RiskFactorDate:          "2016-04-01",
-		ClinicalRisk:            "3",
-		FunctionalRisk:          "2",
-		PsychosocialRisk:        "1",
-		UtilizationRisk:         "4",
-		PerceivedRisk:           "4",
-		RiskFactorsComplete:     "2",
+		StudyID:             float64(1),
+		EventName:           "visit1_arm_1",
+		MedicalRecordNumber: "",
+		RiskFactorDate:      "2016-04-01",
+		ClinicalRisk:        "3",
+		FunctionalRisk:      "2",
+		PsychosocialRisk:    "1",
+		UtilizationRisk:     "4",
+		PerceivedRisk:       "4",
 	}, suite.Records[1])
 	assert.Equal(Record{
-		StudyID:                 "a",
-		EventName:               "initial_arm_1",
-		MedicalRecordNumber:     "1-a",
-		ParticipantInfoComplete: "2",
-		RiskFactorDate:          "2016-02-21",
-		ClinicalRisk:            "1",
-		FunctionalRisk:          "1",
-		PsychosocialRisk:        "2",
-		UtilizationRisk:         "1",
-		PerceivedRisk:           "2",
-		RiskFactorsComplete:     "2",
+		StudyID:             "a",
+		EventName:           "initial_arm_1",
+		MedicalRecordNumber: "1-a",
+		RiskFactorDate:      "2016-02-21",
+		ClinicalRisk:        "1",
+		FunctionalRisk:      "1",
+		PsychosocialRisk:    "2",
+		UtilizationRisk:     "1",
+		PerceivedRisk:       "2",
 	}, suite.Records[2])
 }
 
@@ -96,36 +90,10 @@ func (suite *RecordSuite) TestRiskFactorDateTime() {
 	assert.Equal(time.Date(2016, time.February, 21, 0, 0, 0, 0, time.Local), t)
 }
 
-func (suite *RecordSuite) TestIsParticipationInfoComplete() {
-	assert := suite.Assert()
-	record := suite.Records[0]
-	assert.True(record.IsParticipationInfoComplete())
-
-	record = suite.Records[0]
-	record.ParticipantInfoComplete = ""
-	assert.False(record.IsParticipationInfoComplete(), "Empty ParticipantInfoComplete flag indicates NOT complete")
-
-	record = suite.Records[0]
-	record.ParticipantInfoComplete = "1"
-	assert.False(record.IsParticipationInfoComplete(), "Non-2 ParticipantInfoComplete flag indicates NOT complete")
-
-	record = suite.Records[0]
-	record.MedicalRecordNumber = ""
-	assert.False(record.IsParticipationInfoComplete(), "Empty MedicalRecordNumber indicates NOT complete")
-}
-
 func (suite *RecordSuite) TestIsRiskFactorsComplete() {
 	assert := suite.Assert()
 	record := suite.Records[0]
 	assert.True(record.IsRiskFactorsComplete())
-
-	record = suite.Records[0]
-	record.RiskFactorsComplete = ""
-	assert.False(record.IsRiskFactorsComplete(), "Empty RiskFactorsComplete flag indicates NOT complete")
-
-	record = suite.Records[0]
-	record.RiskFactorsComplete = "1"
-	assert.False(record.IsRiskFactorsComplete(), "Non-2 RiskFactorsComplete flag indicates NOT complete")
 
 	record = suite.Records[0]
 	record.ClinicalRisk = ""
@@ -158,7 +126,7 @@ func (suite *RecordSuite) TestIncompleteRiskFactorsToPie() {
 	assert := suite.Assert()
 
 	record := suite.Records[0]
-	record.RiskFactorsComplete = ""
+	record.ClinicalRisk = ""
 	pie, err := record.ToPie("http://fhir/Patient/1")
 	assert.Nil(pie)
 	assert.Error(err)

--- a/models/record_test.go
+++ b/models/record_test.go
@@ -36,7 +36,6 @@ func (suite *RecordSuite) TestLoadRecordsFromJSON() {
 	assert.Equal(Record{
 		StudyID:             float64(1),
 		EventName:           "initial_arm_1",
-		MedicalRecordNumber: "1-1",
 		RiskFactorDate:      "2015-12-07",
 		ClinicalRisk:        "3",
 		FunctionalRisk:      "2",
@@ -47,7 +46,6 @@ func (suite *RecordSuite) TestLoadRecordsFromJSON() {
 	assert.Equal(Record{
 		StudyID:             float64(1),
 		EventName:           "visit1_arm_1",
-		MedicalRecordNumber: "",
 		RiskFactorDate:      "2016-04-01",
 		ClinicalRisk:        "3",
 		FunctionalRisk:      "2",
@@ -58,7 +56,6 @@ func (suite *RecordSuite) TestLoadRecordsFromJSON() {
 	assert.Equal(Record{
 		StudyID:             "a",
 		EventName:           "initial_arm_1",
-		MedicalRecordNumber: "1-a",
 		RiskFactorDate:      "2016-02-21",
 		ClinicalRisk:        "1",
 		FunctionalRisk:      "1",

--- a/models/study.go
+++ b/models/study.go
@@ -9,11 +9,10 @@ import (
 // Study represents a single study / patient, containing all of the records making up the study
 type Study struct {
 	ID                  string
-	MedicalRecordNumber string
 	Records             []Record
 }
 
-// AddRecord adds a record to the study, checking to ensure it has the same ID and MRN (if available)
+// AddRecord adds a record to the study, checking to ensure it has the same Study ID
 func (s *Study) AddRecord(r Record) error {
 	// Make sure the study ID's match, setting the study ID if necessary
 	if r.StudyID != "" {
@@ -21,16 +20,6 @@ func (s *Study) AddRecord(r Record) error {
 			s.ID = r.StudyIDString()
 		} else if s.ID != r.StudyIDString() {
 			return fmt.Errorf("Record with study ID %s cannot be added to study with ID %s", r.StudyID, s.ID)
-		}
-	}
-
-	// Make sure the MRN's match, setting the study MRN if necessary
-	if r.MedicalRecordNumber != "" {
-		if s.MedicalRecordNumber == "" {
-			s.MedicalRecordNumber = r.MedicalRecordNumber
-		} else if s.MedicalRecordNumber != r.MedicalRecordNumber {
-			return fmt.Errorf("Record with MRN %s cannot be added to study with MRN %s", r.MedicalRecordNumber,
-				s.MedicalRecordNumber)
 		}
 	}
 

--- a/models/study_test.go
+++ b/models/study_test.go
@@ -184,7 +184,7 @@ func (suite *StudySuite) TestToRiskServiceCalculationResultsIgnoresIncompletes()
 	study := new(Study)
 	study.AddRecord(suite.Records[0])
 	incomplete := suite.Records[1]
-	incomplete.RiskFactorsComplete = ""
+	incomplete.FunctionalRisk = ""
 	study.AddRecord(incomplete)
 	assert.Len(study.Records, 2)
 	results := study.ToRiskServiceCalculationResults("http://fhir/Patient/1")

--- a/models/study_test.go
+++ b/models/study_test.go
@@ -38,31 +38,11 @@ func (suite *StudySuite) TestAddOneRecord() {
 	err := study.AddRecord(suite.Records[0])
 	assert.NoError(err)
 	assert.Equal("1", study.ID)
-	assert.Equal("1-1", study.MedicalRecordNumber)
 	assert.Len(study.Records, 1)
 	assert.Equal(suite.Records[0], study.Records[0])
 }
 
-func (suite *StudySuite) TestAddSecondRecordWithoutMRN() {
-	assert := suite.Assert()
-
-	study := new(Study)
-
-	// Add first record
-	err := study.AddRecord(suite.Records[0])
-	assert.NoError(err)
-
-	// Add second record
-	err = study.AddRecord(suite.Records[1])
-	assert.NoError(err)
-	assert.Equal("1", study.ID)
-	assert.Equal("1-1", study.MedicalRecordNumber)
-	assert.Len(study.Records, 2)
-	assert.Equal(suite.Records[0], study.Records[0])
-	assert.Equal(suite.Records[1], study.Records[1])
-}
-
-func (suite *StudySuite) TestAddSecondRecordWithMatchingMRN() {
+func (suite *StudySuite) TestTwoRecords() {
 	assert := suite.Assert()
 
 	study := new(Study)
@@ -73,32 +53,8 @@ func (suite *StudySuite) TestAddSecondRecordWithMatchingMRN() {
 
 	// Add second record
 	second := suite.Records[1]
-	second.MedicalRecordNumber = "1-1"
 	err = study.AddRecord(second)
 	assert.NoError(err)
-}
-
-func (suite *StudySuite) TestAddRecordWithoutMRNFirst() {
-	assert := suite.Assert()
-
-	study := new(Study)
-
-	// Add second record first since it doesn't have an MRN
-	err := study.AddRecord(suite.Records[1])
-	assert.NoError(err)
-	assert.Equal("1", study.ID)
-	assert.Empty(study.MedicalRecordNumber)
-	assert.Len(study.Records, 1)
-	assert.Equal(suite.Records[1], study.Records[0])
-
-	// Then add first record with MRN
-	err = study.AddRecord(suite.Records[0])
-	assert.NoError(err)
-	assert.Equal("1", study.ID)
-	assert.Equal("1-1", study.MedicalRecordNumber)
-	assert.Len(study.Records, 2)
-	assert.Equal(suite.Records[1], study.Records[0])
-	assert.Equal(suite.Records[0], study.Records[1])
 }
 
 func (suite *StudySuite) TestAddSecondRecordWithNonMatchingStudyID() {
@@ -113,22 +69,6 @@ func (suite *StudySuite) TestAddSecondRecordWithNonMatchingStudyID() {
 	// Add second record
 	second := suite.Records[1]
 	second.StudyID = 2
-	err = study.AddRecord(second)
-	assert.Error(err)
-}
-
-func (suite *StudySuite) TestAddSecondRecordWithNonMatchingMRN() {
-	assert := suite.Assert()
-
-	study := new(Study)
-
-	// Add first record
-	err := study.AddRecord(suite.Records[0])
-	assert.NoError(err)
-
-	// Add second record
-	second := suite.Records[1]
-	second.MedicalRecordNumber = "1-2"
 	err = study.AddRecord(second)
 	assert.Error(err)
 }
@@ -208,7 +148,6 @@ func (suite *StudySuite) TestStudyMapAddRecord() {
 	s, ok := m["1"]
 	require.True(ok)
 	assert.Equal("1", s.ID)
-	assert.Equal("1-1", s.MedicalRecordNumber)
 	require.Len(s.Records, 1)
 	assert.Equal(suite.Records[0], s.Records[0])
 
@@ -227,7 +166,6 @@ func (suite *StudySuite) TestStudyMapAddRecords() {
 	s, ok := m["1"]
 	require.True(ok)
 	assert.Equal("1", s.ID)
-	assert.Equal("1-1", s.MedicalRecordNumber)
 	require.Len(s.Records, 2)
 	assert.Equal(suite.Records[0], s.Records[0])
 	assert.Equal(suite.Records[1], s.Records[1])
@@ -235,7 +173,6 @@ func (suite *StudySuite) TestStudyMapAddRecords() {
 	s, ok = m["a"]
 	require.True(ok)
 	assert.Equal("a", s.ID)
-	assert.Equal("1-a", s.MedicalRecordNumber)
 	require.Len(s.Records, 1)
 	assert.Equal(suite.Records[2], s.Records[0])
 }

--- a/server/cron.go
+++ b/server/cron.go
@@ -9,9 +9,9 @@ import (
 )
 
 // ScheduleRefreshRiskAssessmentsCron schedules a cron job for refreshing the risk assessments
-func ScheduleRefreshRiskAssessmentsCron(c *cron.Cron, spec string, fhirEndpoint, redcapEndpoint, redcapToken string, pieCollection *mgo.Collection, basisPieURL string, useStudyID bool) error {
+func ScheduleRefreshRiskAssessmentsCron(c *cron.Cron, spec string, fhirEndpoint, redcapEndpoint, redcapToken string, pieCollection *mgo.Collection, basisPieURL string) error {
 	return c.AddFunc(spec, func() {
-		results, err := client.RefreshRiskAssessments(fhirEndpoint, redcapEndpoint, redcapToken, pieCollection, basisPieURL, useStudyID)
+		results, err := client.RefreshRiskAssessments(fhirEndpoint, redcapEndpoint, redcapToken, pieCollection, basisPieURL)
 		if err != nil {
 			log.Println("Error refreshing risk assessments", err)
 		} else {

--- a/server/cron_test.go
+++ b/server/cron_test.go
@@ -106,7 +106,7 @@ func (suite *CronSuite) TestCron() {
 
 	// Schedule the cron
 	c := cron.New()
-	err := ScheduleRefreshRiskAssessmentsCron(c, "@every 1s", suite.FHIRServer.URL, suite.REDCapServer.URL, "12345", suite.Database.C("pies"), "http://example.org/pies/", false)
+	err := ScheduleRefreshRiskAssessmentsCron(c, "@every 1s", suite.FHIRServer.URL, suite.REDCapServer.URL, "12345", suite.Database.C("pies"), "http://example.org/pies/")
 	c.Start()
 	defer c.Stop()
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -11,9 +11,9 @@ import (
 )
 
 // RegisterRoutes sets up the http request handlers with Gin
-func RegisterRoutes(e *gin.Engine, fhirEndpoint, redcapEndpoint, redcapToken string, pieCollection *mgo.Collection, basisPieURL string, useStudyID bool) {
+func RegisterRoutes(e *gin.Engine, fhirEndpoint, redcapEndpoint, redcapToken string, pieCollection *mgo.Collection, basisPieURL string) {
 	RegisterPieHandler(e, pieCollection)
-	RegisterRefreshHandler(e, fhirEndpoint, redcapEndpoint, redcapToken, pieCollection, basisPieURL, useStudyID)
+	RegisterRefreshHandler(e, fhirEndpoint, redcapEndpoint, redcapToken, pieCollection, basisPieURL)
 }
 
 // RegisterPieHandler registers the handler to return pies from the database
@@ -36,9 +36,9 @@ func RegisterPieHandler(e *gin.Engine, pieCollection *mgo.Collection) {
 }
 
 // RegisterRefreshHandler registers the handler to refresh risk assessments from REDCap
-func RegisterRefreshHandler(e *gin.Engine, fhirEndpoint, redcapEndpoint, redcapToken string, pieCollection *mgo.Collection, basisPieURL string, useStudyID bool) {
+func RegisterRefreshHandler(e *gin.Engine, fhirEndpoint, redcapEndpoint, redcapToken string, pieCollection *mgo.Collection, basisPieURL string) {
 	e.POST("/refresh", func(c *gin.Context) {
-		results, err := client.RefreshRiskAssessments(fhirEndpoint, redcapEndpoint, redcapToken, pieCollection, basisPieURL, useStudyID)
+		results, err := client.RefreshRiskAssessments(fhirEndpoint, redcapEndpoint, redcapToken, pieCollection, basisPieURL)
 		if err != nil {
 			c.AbortWithError(http.StatusInternalServerError, err)
 			return

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -75,7 +75,7 @@ func (suite *RoutesSuite) SetupTest() {
 
 	e := gin.New()
 	suite.Server = httptest.NewServer(e)
-	RegisterRoutes(e, suite.FHIRServer.URL, suite.REDCapServer.URL, "123abc", suite.Database.C("pies"), suite.Server.URL+"/pies/", false)
+	RegisterRoutes(e, suite.FHIRServer.URL, suite.REDCapServer.URL, "123abc", suite.Database.C("pies"), suite.Server.URL+"/pies/")
 }
 
 func (suite *RoutesSuite) TearDownTest() {
@@ -121,14 +121,12 @@ func (suite *RoutesSuite) TestRefresh() {
 	assert.Len(results, 2)
 	assert.Contains(results, client.Result{
 		StudyID:             "1",
-		MedicalRecordNumber: "1-1",
 		FHIRPatientID:       "56fd63cdac1c5d77f6f695a1",
 		RiskAssessmentCount: 2,
 		Error:               nil,
 	})
 	assert.Contains(results, client.Result{
 		StudyID:             "a",
-		MedicalRecordNumber: "1-a",
 		FHIRPatientID:       "56fd63cdac1c5d77f6f695a2",
 		RiskAssessmentCount: 1,
 		Error:               nil,


### PR DESCRIPTION
Updates based on changes to integration environment:
- Do not use participation_information_complete flag.  If there is a study ID, that is enough.
- Do not use risk_factors_complete flag.  If all the necessary risk factor scores are there, that is enough.
- Do not track medical_record_number separate from Study ID.  In our case, the Study ID is the MRN, and often the MRN field was not being filled out consistently.
