### PR TITLE
Add dockerize

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,3 +12,10 @@ RUN go build
 
 # Document that the service listens on port 9000.
 EXPOSE 9000
+
+# Install Dockerize to get support for waiting on another container's port to be available.
+# This is needed here so docker-compose can be configured to wait on the mongodb port to be available.
+RUN apt-get update && apt-get install -y wget
+ENV DOCKERIZE_VERSION v0.2.0
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+    && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz


### PR DESCRIPTION
Add the dockerize tool to the Docker image.  This allows docker-compose to specify that the container should wait for the mongoldb port.
